### PR TITLE
Use flyway for schema generation not hibernate. To make this work in …

### DIFF
--- a/java-to-kotlin-complete/pom.xml
+++ b/java-to-kotlin-complete/pom.xml
@@ -153,6 +153,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>${flyway.version}</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/java-to-kotlin-complete/src/test/resources/config/application.yaml
+++ b/java-to-kotlin-complete/src/test/resources/config/application.yaml
@@ -2,7 +2,7 @@ spring:
   flyway:
     enabled: true
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+    url: jdbc:h2:mem:test
     username: sa
     password: password
     driverClassName: org.h2.Driver

--- a/java-to-kotlin/pom.xml
+++ b/java-to-kotlin/pom.xml
@@ -46,6 +46,25 @@
     </dependencies>
     <build>
         <finalName>recipe-java</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>${flyway.version}</version>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/java-to-kotlin/src/main/resources/application.yaml
+++ b/java-to-kotlin/src/main/resources/application.yaml
@@ -2,12 +2,10 @@ spring:
   flyway:
     enabled: true
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=PostgreSQL
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
     username: sa
     password: password
     driverClassName: org.h2.Driver
   jpa:
     spring.jpa.database-platform: org.hibernate.dialect.H2Dialect
     show-sql: true
-    hibernate:
-      ddl-auto: create-drop

--- a/java-to-kotlin/src/main/resources/try_out_recipes_api.http
+++ b/java-to-kotlin/src/main/resources/try_out_recipes_api.http
@@ -1,0 +1,65 @@
+### Create Recipe
+
+POST localhost:8080/recipes
+Content-Type: application/json
+
+{
+  "recipeName": "Pizza",
+  "ingredients": [
+    {
+      "name": "flower",
+      "weight": 1000,
+      "type": "DRY"
+    },{
+      "name": "water",
+      "weight": 800,
+      "type": "WET"
+    },{
+      "name": "yeast",
+      "weight": 10,
+      "type": "DRY"
+    }
+  ]
+}
+
+### Update recipe
+
+PUT localhost:8080/recipes/1
+Content-Type: application/json
+
+{
+  "recipeName": "Pizza",
+  "ingredients": [
+    {
+      "name": "flower",
+      "weight": 1000,
+      "type": "DRY"
+    },{
+      "name": "water",
+      "weight": 800,
+      "type": "WET"
+    },{
+      "name": "yeast",
+      "weight": 10,
+      "type": "DRY"
+    },{
+      "name": "Olive oil",
+      "weight": 40,
+      "type": "WET"
+    }
+  ]
+}
+
+### Get all recipes
+
+GET localhost:8080/recipes
+Accept: application/json
+
+### Get a recipe
+
+GET localhost:8080/recipes/1
+Accept: application/json
+
+### Delete a recipe
+
+DELETE  localhost:8080/recipes/1

--- a/java-to-kotlin/src/test/java/nl/rabobank/kotlinmovement/recipes/test/util/RecipeTest.java
+++ b/java-to-kotlin/src/test/java/nl/rabobank/kotlinmovement/recipes/test/util/RecipeTest.java
@@ -8,10 +8,12 @@ import nl.rabobank.kotlinmovement.recipes.test.util.model.RecipesErrorResponseTe
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -101,3 +103,4 @@ public class RecipeTest {
     }
 
 }
+

--- a/java-to-kotlin/src/test/resources/config/application.yaml
+++ b/java-to-kotlin/src/test/resources/config/application.yaml
@@ -2,7 +2,7 @@ spring:
   flyway:
     enabled: true
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+    url: jdbc:h2:mem:test
     username: sa
     password: password
     driverClassName: org.h2.Driver

--- a/pom.xml
+++ b/pom.xml
@@ -18,33 +18,11 @@
     <version>1.0.0-SNAPSHOT</version>
     <name>recipes</name>
     <description>Provides CRUD operations for the recipes data.</description>
+
     <properties>
         <java.version>11</java.version>
         <flyway.version>9.4.0</flyway.version>
         <rest-assured.version>5.0.1</rest-assured.version>
     </properties>
-
-	<build>
-		<finalName>recipes</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.flywaydb</groupId>
-				<artifactId>flyway-maven-plugin</artifactId>
-				<version>${flyway.version}</version>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>


### PR DESCRIPTION
Use flyway for schema generation not hibernate. To make this work in the integration test the H2 in mem should close after the last connection (NOT DB_CLOSE_DELAY=-1).

Unrelated small improvement:
- moved out the plugins from the parent pom to its children
- added a http file with example calls
