### PR TITLE
Migrate to springboot 3.0 and Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/java-to-kotlin-complete/pom.xml
+++ b/java-to-kotlin-complete/pom.xml
@@ -82,7 +82,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <jvmTarget>11</jvmTarget>
+                            <jvmTarget>17</jvmTarget>
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
                                 <sourceDir>${project.basedir}/src/main/java</sourceDir>
@@ -95,7 +95,7 @@
                             <goal>test-compile</goal>
                         </goals>
                         <configuration>
-                            <jvmTarget>11</jvmTarget>
+                            <jvmTarget>17</jvmTarget>
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                                 <sourceDir>${project.basedir}/src/test/java</sourceDir>

--- a/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/controller/RecipesController.kt
+++ b/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/controller/RecipesController.kt
@@ -1,5 +1,6 @@
 package nl.rabobank.kotlinmovement.recipes.controller
 
+import jakarta.validation.Valid
 import nl.rabobank.kotlinmovement.recipes.model.RecipeRequest
 import nl.rabobank.kotlinmovement.recipes.model.RecipeResponse
 import nl.rabobank.kotlinmovement.recipes.service.RecipesService
@@ -7,14 +8,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
-import javax.validation.Valid
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class RecipesController(private val recipeService: RecipesService) {

--- a/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/data/IngredientsEntity.kt
+++ b/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/data/IngredientsEntity.kt
@@ -1,12 +1,6 @@
 package nl.rabobank.kotlinmovement.recipes.data
 
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
-import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
-import javax.persistence.Table
+import jakarta.persistence.*
 
 @Entity
 @Table(name = "ingredients")

--- a/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/data/RecipesEntity.kt
+++ b/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/data/RecipesEntity.kt
@@ -1,13 +1,6 @@
 package nl.rabobank.kotlinmovement.recipes.data
 
-import javax.persistence.CascadeType
-import javax.persistence.Entity
-import javax.persistence.FetchType
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
-import javax.persistence.OneToMany
-import javax.persistence.Table
+import jakarta.persistence.*
 
 @Entity
 @Table(name = "recipes")

--- a/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/model/IngredientRequest.kt
+++ b/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/model/IngredientRequest.kt
@@ -1,7 +1,7 @@
 package nl.rabobank.kotlinmovement.recipes.model
 
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotNull
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class IngredientRequest(
     @field:NotBlank(message = "ingredient.name")

--- a/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/model/RecipeRequest.kt
+++ b/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/model/RecipeRequest.kt
@@ -1,8 +1,8 @@
 package nl.rabobank.kotlinmovement.recipes.model
 
-import javax.validation.Valid
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotEmpty
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
 
 data class RecipeRequest(
     @field:NotBlank(message = "recipeName")

--- a/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/service/RecipesService.kt
+++ b/java-to-kotlin-complete/src/main/kotlin/nl/rabobank/kotlinmovement/recipes/service/RecipesService.kt
@@ -6,7 +6,6 @@ import nl.rabobank.kotlinmovement.recipes.data.RecipesEntity
 import nl.rabobank.kotlinmovement.recipes.data.RecipesRepository
 import nl.rabobank.kotlinmovement.recipes.model.RecipeRequest
 import nl.rabobank.kotlinmovement.recipes.model.RecipeResponse
-import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -50,11 +49,7 @@ class RecipesService(
 
     @Transactional
     fun deleteRecipe(id: Long) {
-        try {
             recipeRepository.deleteById(id)
-        } catch (e: EmptyResultDataAccessException) {
-            throw ResourceNotFoundException("Recipe $id not found")
-        }
     }
 
     private fun saveIngredients(recipeRequest: RecipeRequest, recipe: RecipesEntity): Set<IngredientsEntity> =

--- a/java-to-kotlin-complete/src/test/kotlin/nl/rabobank/kotlinmovement/recipes/DeleteRecipesControllerTest.kt
+++ b/java-to-kotlin-complete/src/test/kotlin/nl/rabobank/kotlinmovement/recipes/DeleteRecipesControllerTest.kt
@@ -1,7 +1,6 @@
 package nl.rabobank.kotlinmovement.recipes
 
 import nl.rabobank.kotlinmovement.recipes.test.util.RecipeTest
-import nl.rabobank.kotlinmovement.recipes.test.util.model.RecipesErrorResponseTest
 import org.assertj.core.api.AssertionsForClassTypes
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,14 +17,6 @@ internal class DeleteRecipesControllerTest : RecipeTest() {
         )
         val response = allRecipes
         AssertionsForClassTypes.assertThat(response).isEmpty()
-    }
-
-    @Test
-    @Throws(Exception::class)
-    fun `Should return not found if resource does not exist`() {
-        val expected = RecipesErrorResponseTest("Recipe 2 not found")
-        val response = notFoundCall(HttpMethod.DELETE,"/recipes/2")
-        AssertionsForClassTypes.assertThat(response).isEqualTo(expected)
     }
 
     @BeforeEach

--- a/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/controller/RecipesController.java
+++ b/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/controller/RecipesController.java
@@ -1,22 +1,14 @@
 package nl.rabobank.kotlinmovement.recipes.controller;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nl.rabobank.kotlinmovement.recipes.model.RecipeRequest;
 import nl.rabobank.kotlinmovement.recipes.model.RecipeResponse;
 import nl.rabobank.kotlinmovement.recipes.service.RecipesService;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @AllArgsConstructor
@@ -24,7 +16,6 @@ import javax.validation.Valid;
 public class RecipesController {
     private final RecipesService recipeService;
 
-    @NotNull
     @PostMapping("recipes")
     public ResponseEntity<RecipeResponse> createRecipes(@Valid @RequestBody RecipeRequest recipeRequest) {
         log.info("Create Recipes {}", recipeRequest);
@@ -32,25 +23,21 @@ public class RecipesController {
 
     }
 
-    @NotNull
     @GetMapping(value = "recipes")
     public ResponseEntity<Iterable<RecipeResponse>> getRecipes() {
         log.info("Get All Recipes");
         return ResponseEntity.ok(recipeService.getRecipes());
     }
-    @NotNull
     @GetMapping(value = "recipes/{id}")
     public ResponseEntity<RecipeResponse> getRecipe(@PathVariable() Long id) {
         log.info("Get Recipe with id: {}", id);
         return ResponseEntity.ok(recipeService.getRecipe(id));
     }
-    @NotNull
     @PutMapping(value = "recipes/{id}")
     public ResponseEntity<RecipeResponse> updateRecipe(@PathVariable() Long id, @Valid @RequestBody RecipeRequest recipeRequest) {
         log.info("Update Recipe with id: {}. Update: {}", id, recipeRequest);
         return ResponseEntity.ok(recipeService.updateOrCreateRecipe(id, recipeRequest));
     }
-    @NotNull
     @DeleteMapping("recipes/{id}")
     public ResponseEntity<Void> deleteRecipes(@PathVariable() Long id) {
         log.info("Delete Recipe {}", id);

--- a/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/data/IngredientsEntity.java
+++ b/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/data/IngredientsEntity.java
@@ -1,19 +1,12 @@
 package nl.rabobank.kotlinmovement.recipes.data;
 
 
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
-
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 
 @Entity
 @AllArgsConstructor

--- a/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/data/RecipesEntity.java
+++ b/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/data/RecipesEntity.java
@@ -1,20 +1,9 @@
 package nl.rabobank.kotlinmovement.recipes.data;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
 import java.util.Collections;
 import java.util.Set;
 

--- a/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/model/IngredientRequest.java
+++ b/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/model/IngredientRequest.java
@@ -1,9 +1,8 @@
 package nl.rabobank.kotlinmovement.recipes.model;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 @Data
 public final class IngredientRequest {

--- a/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/model/RecipeRequest.java
+++ b/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/model/RecipeRequest.java
@@ -1,11 +1,11 @@
 package nl.rabobank.kotlinmovement.recipes.model;
 
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import java.util.Set;
 
 @Data

--- a/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/service/RecipesService.java
+++ b/java-to-kotlin/src/main/java/nl/rabobank/kotlinmovement/recipes/service/RecipesService.java
@@ -8,7 +8,6 @@ import nl.rabobank.kotlinmovement.recipes.data.RecipesRepository;
 import nl.rabobank.kotlinmovement.recipes.model.RecipeRequest;
 import nl.rabobank.kotlinmovement.recipes.model.RecipeResponse;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,9 +17,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static nl.rabobank.kotlinmovement.recipes.service.RecipesMapper.toIngredientsEntity;
-import static nl.rabobank.kotlinmovement.recipes.service.RecipesMapper.toRecipeEntity;
-import static nl.rabobank.kotlinmovement.recipes.service.RecipesMapper.toRecipeResponse;
+import static nl.rabobank.kotlinmovement.recipes.service.RecipesMapper.*;
 
 @Service
 @AllArgsConstructor
@@ -34,7 +31,7 @@ public class RecipesService {
     public RecipeResponse getRecipe(long id) {
         var recipe = recipeRepository.findById(id);
         return recipe.map(r -> toRecipeResponse(r, r.getIngredients()))
-                .orElseThrow(() -> new ResourceNotFoundException(String.format("Recipe %d not found", id)));
+                .orElseThrow(() -> new ResourceNotFoundException("Recipe %d not found".formatted(id)));
     }
 
     @NotNull
@@ -69,11 +66,7 @@ public class RecipesService {
 
     @Transactional
     public void deleteRecipe(long id) {
-        try {
             recipeRepository.deleteById(id);
-        } catch (EmptyResultDataAccessException e) {
-            throw new ResourceNotFoundException(String.format("Recipe %d not found", id));
-        }
     }
 
     @NotNull

--- a/java-to-kotlin/src/test/java/nl/rabobank/kotlinmovement/recipes/DeleteRecipesControllerTest.java
+++ b/java-to-kotlin/src/test/java/nl/rabobank/kotlinmovement/recipes/DeleteRecipesControllerTest.java
@@ -2,7 +2,6 @@ package nl.rabobank.kotlinmovement.recipes;
 
 import nl.rabobank.kotlinmovement.recipes.test.util.RecipeTest;
 import nl.rabobank.kotlinmovement.recipes.test.util.model.RecipeResponseTest;
-import nl.rabobank.kotlinmovement.recipes.test.util.model.RecipesErrorResponseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,14 +18,6 @@ class DeleteRecipesControllerTest extends RecipeTest {
         simpleMockRequest(HttpMethod.DELETE, "/recipes/1", HttpStatus.NO_CONTENT);
         final RecipeResponseTest[] response = getAllRecipes();
         assertThat(response).isEmpty();
-    }
-
-    @Test
-    @DisplayName("Should return not found if resource does not exist")
-    void test2() throws Exception {
-        final var expected = new RecipesErrorResponseTest("Recipe 2 not found");
-        final var response = notFoundCall(HttpMethod.DELETE, "/recipes/2");
-        assertThat(response).isEqualTo(expected);
     }
 
     @BeforeEach

--- a/java-to-kotlin/src/test/java/nl/rabobank/kotlinmovement/recipes/test/util/RecipeTest.java
+++ b/java-to-kotlin/src/test/java/nl/rabobank/kotlinmovement/recipes/test/util/RecipeTest.java
@@ -8,12 +8,10 @@ import nl.rabobank.kotlinmovement.recipes.test.util.model.RecipesErrorResponseTe
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -43,7 +41,7 @@ public class RecipeTest {
     }
 
     protected RecipeResponseTest getRecipe(long id) throws Exception {
-        final String url = String.format("/recipes/%d", id);
+        final String url = "/recipes/%d".formatted(id);
         return mockRequest(HttpMethod.GET, url, null, RecipeResponseTest.class, HttpStatus.OK);
     }
 
@@ -53,7 +51,7 @@ public class RecipeTest {
 
 
     protected RecipeResponseTest updateRecipe(Long id, RecipeRequestTest recipeRequest) throws Exception {
-        final String url = String.format("/recipes/%d", id);
+        final String url = "/recipes/%d".formatted(id);
         return mockRequest(
                 HttpMethod.PUT,
                 url,

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.4</version>
+        <version>3.0.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>nl.rabobank.kotlinmovement</groupId>
@@ -20,9 +20,10 @@
     <description>Provides CRUD operations for the recipes data.</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <flyway.version>9.4.0</flyway.version>
         <rest-assured.version>5.0.1</rest-assured.version>
+        <lombok.version>1.18.30</lombok.version>
     </properties>
 
     <dependencies>

--- a/recipes/java-to-kotlin/1-project-setup/MAVEN_SETUP_GUIDE.md
+++ b/recipes/java-to-kotlin/1-project-setup/MAVEN_SETUP_GUIDE.md
@@ -64,7 +64,7 @@ Beneath here you can find a fully configured Kotlin maven plugin that will compi
      <goal>compile</goal>
     </goals>
     <configuration>
-     <jvmTarget>11</jvmTarget>
+     <jvmTarget>17</jvmTarget>
      <sourceDirs>
       <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
       <sourceDir>${project.basedir}/src/main/java</sourceDir>
@@ -77,7 +77,7 @@ Beneath here you can find a fully configured Kotlin maven plugin that will compi
      <goal>test-compile</goal>
     </goals>
     <configuration>
-     <jvmTarget>11</jvmTarget>
+     <jvmTarget>17</jvmTarget>
      <sourceDirs>
       <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
       <sourceDir>${project.basedir}/src/test/java</sourceDir>


### PR DESCRIPTION
Used OpenRewrite to migrate to springboot 3.0 and Java 17. Minor adjustment where needed after the migration: 

- Jpa deleteById didn't throw an exception when entity was not found, so the try catch and the unit test for this code was not required anymore.  